### PR TITLE
Fixed 3 issues of type: PYTHON_E225 throughout 3 files in repo.

### DIFF
--- a/HBP_all.py
+++ b/HBP_all.py
@@ -146,7 +146,7 @@ class HBPManager(object):
                 ii += 1
                 x = torch.Tensor([ii])
                 y = torch.Tensor([loss.data[0]])
-                vis.line(X=x, Y=y, win='polynomial', update='append' if ii>0 else None)
+                vis.line(X=x, Y=y, win='polynomial', update='append' if ii > 0 else None)
 
             num_correct = torch.tensor(num_correct).float().cuda()
             num_total = torch.tensor(num_total).float().cuda()

--- a/HBP_fc.py
+++ b/HBP_fc.py
@@ -171,7 +171,7 @@ class HBPManager(object):
                 ii += 1
                 x = torch.Tensor([ii])
                 y = torch.Tensor([loss.data[0]])
-                vis.line(X=x, Y=y, win='polynomial', update='append' if ii>0 else None)
+                vis.line(X=x, Y=y, win='polynomial', update='append' if ii > 0 else None)
 
             num_correct = torch.tensor(num_correct).float().cuda()
             num_total = torch.tensor(num_total).float().cuda()

--- a/HBP_fc_new.py
+++ b/HBP_fc_new.py
@@ -187,7 +187,7 @@ class HBPManager(object):
                 ii += 1
                 x = torch.Tensor([ii])
                 y = torch.Tensor([loss.data[0]])
-                vis.line(X=x, Y=y, win='polynomial', update='append' if ii>0 else None)
+                vis.line(X=x, Y=y, win='polynomial', update='append' if ii > 0 else None)
 
             num_correct = torch.tensor(num_correct).float().cuda()
             num_total = torch.tensor(num_total).float().cuda()


### PR DESCRIPTION
PYTHON_E225: 'Fix extraneous whitespace around keywords.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.